### PR TITLE
fix(docs): use same middleware name for k8s

### DIFF
--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -77,7 +77,7 @@ metadata:
 spec:
   # highlight-start
   plugin:
-    traefik-oidc-plugin:  # same key as in the static configuration
+    traefik-oidc-auth: # same key as in the static configuration
       Secret: "urn:k8s:secret:oidc-secret:pluginSecret"
       Provider:
         # You could just write strings here for the values.


### PR DESCRIPTION
Hello,

I just noticed the k8s CRD example middlename was different to the other examples.
Would be nice if this would be aligned.
